### PR TITLE
Add druid forms to aura as low priority

### DIFF
--- a/Modules/Auras.lua
+++ b/Modules/Auras.lua
@@ -354,4 +354,9 @@ sArenaMixin.auraList = tInvert({
     322461, -- Thoughtstolen (Priest - Discipline)
     322458, -- Thoughtstolen (Monk)
     322460, -- Thoughtstolen (Priest - Shadow)
+
+    -- Druid Forms
+    768,    -- Cat form
+    783,    -- Travel form
+    5487,   -- Bear form
 })


### PR DESCRIPTION
Add the druid forms to aura display (as lowest priority so it doesn't mess up with other auras), very nice to have for mage/druid/hunter players since it makes it a lot easier to cast polymorph/hibernate/fear beast.