### PR TITLE
Fix the issue where class and spec icons are not updated after the 1st round of solo shuffle

### DIFF
--- a/Modules/Auras.lua
+++ b/Modules/Auras.lua
@@ -178,6 +178,7 @@ sArenaMixin.auraList = tInvert({
     212295, -- Warlock: Nether Ward
     48707,  -- Death Knight: Anti-Magic Shell
     5384,   -- Hunter: Feign Death
+    353319, -- Monk: Peaceweaver
 
     -- Silences
     81261,  -- Solar Beam

--- a/sArena.lua
+++ b/sArena.lua
@@ -383,7 +383,7 @@ function sArenaFrameMixin:OnEvent(event, eventUnit, arg1)
         end
 
         self:Initialize()
-    elseif ( event == "PLAYER_ENTERING_WORLD" ) then
+    elseif ( event == "PLAYER_ENTERING_WORLD" ) or ( event == "ARENA_PREP_OPPONENT_SPECIALIZATIONS" ) then
         self.Name:SetText("")
         self.CastBar:Hide()
         self.specTexture = nil
@@ -396,9 +396,6 @@ function sArenaFrameMixin:OnEvent(event, eventUnit, arg1)
         self:ResetRacial()
         self:ResetDR()
         UnitFrameHealPredictionBars_Update(self)
-    elseif ( event == "ARENA_PREP_OPPONENT_SPECIALIZATIONS" ) then
-        self:UpdateVisible()
-        self:UpdatePlayer()
     elseif ( event == "PLAYER_REGEN_ENABLED" ) then
         self:UnregisterEvent("PLAYER_REGEN_ENABLED")
 


### PR DESCRIPTION
1. Fix the issue where class & spec icons are not updated during solo shuffle rounds.

Currently, after the 1st round of solo shuffle, the class and spec icons no longer update.
I think it's checking PLAYER_ENTERING_WORLD to do a full update, but that event doesn't happen between rounds.

The fix is to also do a full update on ARENA_PREP_OPPONENT_SPECIALIZATIONS, the same way as how we handle PLAYER_ENTERING_WORLD events.
There could be a few redundant checks as I noticed multiple ARENA_PREP_OPPONENT_SPECIALIZATIONS events are fired at the beginning of each round, so we may end up doing a few redundant checks.

Ideally, we only want to do this full update for the first ARENA_PREP_OPPONENT_SPECIALIZATIONS upon entering a new arena or new solo shuffle round, but AFAIK there's no reliable to tell that.

2. Add monk spell immunity Peaceweaver to the bottom of the anti-CC list