### PR TITLE
Update a few key evoker spells

### DIFF
--- a/Modules/Auras.lua
+++ b/Modules/Auras.lua
@@ -90,6 +90,7 @@ sArenaMixin.auraList = tInvert({
     236748, -- Intimidating Roar (Disorient)
     331866, -- Agent of Chaos (Disorient)
     324263, -- Sulfuric Emission (Disorient)
+    360806, -- Sleep Walk (Disorient)
 
     51514,  -- Hex (Incapacitate)
     211004, -- Hex: Spider (Incapacitate)
@@ -230,6 +231,7 @@ sArenaMixin.auraList = tInvert({
     198121, -- Frostbite
     117526, -- Binding Shot
     207171, -- Winter is Coming
+    355689, -- Landslide
 
     -- Offensive Buffs
     51271,  -- Death Knight: Pillar of Frost

--- a/Modules/Auras.lua
+++ b/Modules/Auras.lua
@@ -179,6 +179,7 @@ sArenaMixin.auraList = tInvert({
     48707,  -- Death Knight: Anti-Magic Shell
     5384,   -- Hunter: Feign Death
     353319, -- Monk: Peaceweaver
+    378464, -- Evoker: Nullifying Shroud
 
     -- Silences
     81261,  -- Solar Beam

--- a/Modules/Auras.lua
+++ b/Modules/Auras.lua
@@ -197,7 +197,7 @@ sArenaMixin.auraList = tInvert({
     196364, -- Unstable Affliction Silence 2
     317589, -- Tormenting Backlash
 
-    323673, -- Mindgames
+    375901, -- Mindgames
 
     -- Disarms
     236077, -- Disarm

--- a/Modules/Auras.lua
+++ b/Modules/Auras.lua
@@ -331,6 +331,7 @@ sArenaMixin.auraList = tInvert({
     213871, -- Warrior: Bodyguard
     345231, -- Trinket: Gladiator's Emblem
     197690, -- Warrior: Defensive Stance
+    363916, -- Evoker: Obsidian Scales
 
     -- Refreshments
     167152, -- Mage Food

--- a/Modules/Auras.lua
+++ b/Modules/Auras.lua
@@ -276,6 +276,7 @@ sArenaMixin.auraList = tInvert({
     -- 260708, -- Warrior: Sweeping Strikes
     262228, -- Warrior: Deadly Calm
     1719,   -- Warrior: Recklessness
+    375087, -- Dragonrage
 
     -- Defensive Buffs
     48792,  -- Death Knight: Icebound Fortitude


### PR DESCRIPTION
Add the following evoker spells:
- Sleep Walk (CC)
- Nullifying Shroud (anti CC)
- Landslide (Root)
- Dragonrage (Offensive buff)
- Obsidian Scales (Defensive buff)

Fix the spell ID for Mindgames, which has changed in Dragonflight

All spell IDs have been tested with WeakAuras and BigDebuffs